### PR TITLE
Update train_adversarial_network_2D.py

### DIFF
--- a/code/train_adversarial_network_2D.py
+++ b/code/train_adversarial_network_2D.py
@@ -148,7 +148,7 @@ def train(args, snapshot_path):
             outputs = model(volume_batch)
             outputs_soft = torch.softmax(outputs, dim=1)
 
-            loss_ce = ce_loss(outputs[:args.labeled_bs],
+            loss_ce = ce_loss(outputs_soft[:args.labeled_bs],
                               label_batch[:][:args.labeled_bs].long())
             loss_dice = dice_loss(
                 outputs_soft[:args.labeled_bs], label_batch[:args.labeled_bs].unsqueeze(1))


### PR DESCRIPTION
这里的loss_ce应该用softmax处理之后的outputs才对的吧？而且下面的loss_dice就是用outputs_soft算的。（菜鸡一枚，正在用大佬的代码做毕设，发现这里应该是有问题的？否则Loss就一直降不下来）